### PR TITLE
[Bug-Fix] multiple user_request dispatch and lack of content load on login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const App: React.FC<{}> = () => {
 
   useEffect(() => {
     store.dispatch(loadUserAsync());
-  });
+  }, []);
 
   return (
     <Suspense fallback={<Spinner />}>

--- a/src/features/auth/actions.ts
+++ b/src/features/auth/actions.ts
@@ -8,6 +8,7 @@ import {
 import { setToast } from '../../layout/actions';
 import handleAxiosErrors from '../../utils/handleAxiosErrors';
 import { removeToken, storeToken as saveToken } from '../../utils/token';
+import { resetContent } from '../content/actions';
 
 type Credentials = {
   name?: string;
@@ -42,6 +43,7 @@ export const loadUserAsync = () => async (dispatch: ThunkDispatchAny) => {
     dispatch(loadUser.request());
     const res = await axios.get('/auth');
     dispatch(loadUser.success(res.data));
+    dispatch(resetContent());
   } catch (err) {
     dispatch(loadUser.failure());
   }


### PR DESCRIPTION
I've noticed the behaviour of two user request dispatching from the frontend when logging in or even without any logging in, so they are two tries per-say.
how ever another fetch content bug I found was the refreshing part, I remember this was an old one and it been fixed 🙃but I fixed it again, please check it out 🙂